### PR TITLE
Add Compact option for compact output

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ litter.Config.HomePackage = "mypackage"
 
 // Sets separator used when multiple arguments are passed to Dump() or Sdump().
 litter.Config.Separator = "\n"
+
+// Use compact output: strip newlines and other unnecessary whitespace, and remove pointer comments
+litter.Config.Compact = true
 ```
 
 ### `litter.Options`

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ litter.Config.HomePackage = "mypackage"
 // Sets separator used when multiple arguments are passed to Dump() or Sdump().
 litter.Config.Separator = "\n"
 
-// Use compact output: strip newlines and other unnecessary whitespace, and remove pointer comments
+// Use compact output: strip newlines and other unnecessary whitespace
 litter.Config.Compact = true
 ```
 

--- a/dump.go
+++ b/dump.go
@@ -89,9 +89,7 @@ func (s *dumpState) dumpSlice(v reflect.Value) {
 		return
 	}
 	s.w.Write([]byte("{"))
-	if !s.config.Compact {
-		s.newlineWithPointerNameComment()
-	}
+	s.newlineWithPointerNameComment()
 	s.depth++
 	for i := 0; i < numEntries; i++ {
 		s.indent()

--- a/dump.go
+++ b/dump.go
@@ -53,15 +53,18 @@ func (s *dumpState) indent() {
 }
 
 func (s *dumpState) newlineWithPointerNameComment() {
-	if s.config.Compact {
-		return
-	}
 	if s.currentPointerName != "" {
-		s.w.Write([]byte(fmt.Sprintf(" // %s\n", s.currentPointerName)))
+		if s.config.Compact {
+			s.w.Write([]byte(fmt.Sprintf("/*%s*/", s.currentPointerName)))
+		} else {
+			s.w.Write([]byte(fmt.Sprintf("// %s\n", s.currentPointerName)))
+		}
 		s.currentPointerName = ""
 		return
 	}
-	s.w.Write([]byte("\n"))
+	if !s.config.Compact {
+		s.w.Write([]byte("\n"))
+	}
 }
 
 func (s *dumpState) dumpType(v reflect.Value) {

--- a/dump.go
+++ b/dump.go
@@ -53,6 +53,9 @@ func (s *dumpState) indent() {
 }
 
 func (s *dumpState) newlineWithPointerNameComment() {
+	if s.config.Compact {
+		return
+	}
 	if s.currentPointerName != "" {
 		s.w.Write([]byte(fmt.Sprintf(" // %s\n", s.currentPointerName)))
 		s.currentPointerName = ""
@@ -81,9 +84,8 @@ func (s *dumpState) dumpSlice(v reflect.Value) {
 		s.w.Write([]byte("{}"))
 		if s.config.Compact {
 			s.w.Write([]byte(";"))
-		} else {
-			s.newlineWithPointerNameComment()
 		}
+		s.newlineWithPointerNameComment()
 		return
 	}
 	s.w.Write([]byte("{"))
@@ -97,9 +99,7 @@ func (s *dumpState) dumpSlice(v reflect.Value) {
 		if !s.config.Compact || i < numEntries-1 {
 			s.w.Write([]byte(","))
 		}
-		if !s.config.Compact {
-			s.newlineWithPointerNameComment()
-		}
+		s.newlineWithPointerNameComment()
 	}
 	s.depth--
 	s.indent()
@@ -110,9 +110,7 @@ func (s *dumpState) dumpStruct(v reflect.Value) {
 	dumpPreamble := func() {
 		s.dumpType(v)
 		s.w.Write([]byte("{"))
-		if !s.config.Compact {
-			s.newlineWithPointerNameComment()
-		}
+		s.newlineWithPointerNameComment()
 		s.depth++
 	}
 	preambleDumped := false
@@ -138,9 +136,7 @@ func (s *dumpState) dumpStruct(v reflect.Value) {
 		if !s.config.Compact || i < numFields-1 {
 			s.w.Write([]byte(","))
 		}
-		if !s.config.Compact {
-			s.newlineWithPointerNameComment()
-		}
+		s.newlineWithPointerNameComment()
 	}
 	if preambleDumped {
 		s.depth--
@@ -156,9 +152,7 @@ func (s *dumpState) dumpStruct(v reflect.Value) {
 func (s *dumpState) dumpMap(v reflect.Value) {
 	s.dumpType(v)
 	s.w.Write([]byte("{"))
-	if !s.config.Compact {
-		s.newlineWithPointerNameComment()
-	}
+	s.newlineWithPointerNameComment()
 	s.depth++
 	keys := v.MapKeys()
 	sort.Sort(mapKeySorter{keys})
@@ -175,9 +169,7 @@ func (s *dumpState) dumpMap(v reflect.Value) {
 		if !s.config.Compact || i < numKeys-1 {
 			s.w.Write([]byte(","))
 		}
-		if !s.config.Compact {
-			s.newlineWithPointerNameComment()
-		}
+		s.newlineWithPointerNameComment()
 	}
 	s.depth--
 	s.indent()

--- a/dump_test.go
+++ b/dump_test.go
@@ -118,6 +118,9 @@ func TestSdump_config(t *testing.T) {
 		litter.Config,
 		&BasicStruct{1, 2},
 	}
+	runTestWithCfg(t, "config_Compact", &litter.Options{
+		Compact: true,
+	}, data)
 	runTestWithCfg(t, "config_HidePrivateFields", &litter.Options{
 		HidePrivateFields: true,
 	}, data)

--- a/testdata/config_Compact.dump
+++ b/testdata/config_Compact.dump
@@ -1,0 +1,1 @@
+[]interface{}{litter.Options{Compact:false,StripPackageNames:false,HidePrivateFields:true,HomePackage:"",Separator:" "},&litter_test.BasicStruct{Public:1,private:2}}

--- a/testdata/config_HidePrivateFields.dump
+++ b/testdata/config_HidePrivateFields.dump
@@ -1,5 +1,6 @@
 []interface {}{
   litter.Options{
+    Compact: false,
     StripPackageNames: false,
     HidePrivateFields: true,
     HomePackage: "",

--- a/testdata/config_HomePackage.dump
+++ b/testdata/config_HomePackage.dump
@@ -1,5 +1,6 @@
 []interface {}{
   litter.Options{
+    Compact: false,
     StripPackageNames: false,
     HidePrivateFields: true,
     HomePackage: "",

--- a/testdata/config_StripPackageNames.dump
+++ b/testdata/config_StripPackageNames.dump
@@ -1,5 +1,6 @@
 []interface {}{
   Options{
+    Compact: false,
     StripPackageNames: false,
     HidePrivateFields: true,
     HomePackage: "",


### PR DESCRIPTION
This adds a `Compact` option, which removes newlines and other unnecessary whitespace, as well as pointer comments.

With `Compact: false`:

```go
main.Struct{
  String: "some string",
  Bool: true,
  Float: 3.14,
  Map: map[string]bool{
    "false": false,
    "true": true,
  },
  Substruct: struct { Subint int64; Subslice []string }{
    Subint: 7,
    Subslice: []string{
      "a",
      "b",
      "c",
    },
  },
}
```

With `Compact: true`:

```go
main.Struct{String:"some string",Bool:true,Float:3.14,Map:map[string]bool{"false":false,"true":true},Substruct:struct{Subint int64;Subslice []string}{Subint:7,Subslice:[]string{"a","b","c"}}}
```

Verified to produce compilable Go code.