### PR TITLE
Prevent panic when dumping unexported map

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -425,5 +425,9 @@ func (s mapKeySorter) Swap(i, j int) {
 }
 
 func (s mapKeySorter) Less(i, j int) bool {
-	return fmt.Sprintf("%s", s.keys[i].Interface()) < fmt.Sprintf("%s", s.keys[j].Interface())
+	if s.keys[i].CanInterface() && s.keys[j].CanInterface() {
+		return fmt.Sprintf("%s", s.keys[i].Interface()) < fmt.Sprintf("%s", s.keys[j].Interface())
+	}
+	
+	return true
 }


### PR DESCRIPTION
Fixes #18 

Tried some of the standard tricks for accessing unexported values but none worked. This fix isn't ideal because the resulting key order is non-deterministic but at least it doesn't panic.