### PR TITLE
Add support for dumping functions

### DIFF
--- a/dump_test.go
+++ b/dump_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Function(arg1 string, arg2 int) (string, error) {
+	return "", nil
+}
+
 type BlankStruct struct{}
 
 type BasicStruct struct {
@@ -66,6 +70,8 @@ func TestSdump_primitives(t *testing.T) {
 		BlankStruct{},
 		&BlankStruct{},
 		BasicStruct{1, 2},
+		Function,
+		func(arg string) (bool, error) { return false, nil },
 		nil,
 		interface{}(nil),
 	})
@@ -117,6 +123,9 @@ func TestSdump_config(t *testing.T) {
 	data := []interface{}{
 		litter.Config,
 		&BasicStruct{1, 2},
+		Function,
+		litter.Dump,
+		func(s string, i int) (bool, error) { return false, nil },
 	}
 	runTestWithCfg(t, "config_Compact", &litter.Options{
 		Compact: true,

--- a/testdata/config_Compact.dump
+++ b/testdata/config_Compact.dump
@@ -1,1 +1,1 @@
-[]interface{}{litter.Options{Compact:false,StripPackageNames:false,HidePrivateFields:true,HomePackage:"",Separator:" "},&litter_test.BasicStruct{Public:1,private:2}}
+[]interface{}{litter.Options{Compact:false,StripPackageNames:false,HidePrivateFields:true,HomePackage:"",Separator:" "},&litter_test.BasicStruct{Public:1,private:2},litter_test.Function,litter.Dump,func(string,int)(bool,error)}

--- a/testdata/config_HidePrivateFields.dump
+++ b/testdata/config_HidePrivateFields.dump
@@ -9,4 +9,7 @@
   &litter_test.BasicStruct{
     Public: 1,
   },
+  litter_test.Function,
+  litter.Dump,
+  func(string, int) (bool, error),
 }

--- a/testdata/config_HomePackage.dump
+++ b/testdata/config_HomePackage.dump
@@ -10,4 +10,7 @@
     Public: 1,
     private: 2,
   },
+  Function,
+  litter.Dump,
+  func(string, int) (bool, error),
 }

--- a/testdata/config_StripPackageNames.dump
+++ b/testdata/config_StripPackageNames.dump
@@ -10,4 +10,7 @@
     Public: 1,
     private: 2,
   },
+  Function,
+  Dump,
+  func(string, int) (bool, error),
 }

--- a/testdata/primitives.dump
+++ b/testdata/primitives.dump
@@ -28,6 +28,8 @@
     Public: 1,
     private: 2,
   },
+  litter_test.Function,
+  func(string) (bool, error),
   nil,
   nil,
 }


### PR DESCRIPTION
Litter currently dumps the pointer address for functions. This adds support for dumping the function name, or the function signature for anonymous functions, e.g.:

```
package pkg
litter.Dump(someFunction)
litter.Dump(func(s string, i int) (bool, error) { return false nil })
```

Yields:

```
pkg.someFunction
func(s string, i int) (bool, error)
```

Note that the anonymous function output breaks the Litter promise of generating compilable Go code, since it would have to include a dummy function body.