### PR TITLE
Better output of reused pointers for diffing

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -13,8 +13,10 @@ import (
 	"strings"
 )
 
-var packageNameStripperRegexp = regexp.MustCompile("\\b[a-zA-Z_]+[a-zA-Z_0-9]+\\.")
-var compactTypeRegexp = regexp.MustCompile(`\s*([,;{}()])\s*`)
+var (
+	packageNameStripperRegexp = regexp.MustCompile(`\b[a-zA-Z_]+[a-zA-Z_0-9]+\.`)
+	compactTypeRegexp         = regexp.MustCompile(`\s*([,;{}()])\s*`)
+)
 
 // Dumper is the interface for implementing custom dumper for your types.
 type Dumper interface {

--- a/dump_test.go
+++ b/dump_test.go
@@ -151,6 +151,7 @@ func TestSdump_config(t *testing.T) {
 		litter.Dump,
 		func(s string, i int) (bool, error) { return false, nil },
 	}
+
 	runTestWithCfg(t, "config_Compact", &litter.Options{
 		Compact: true,
 	}, data)
@@ -174,6 +175,16 @@ func TestSdump_config(t *testing.T) {
 	runTestWithCfg(t, "config_StrictGo", &litter.Options{
 		StrictGo: true,
 	}, data)
+
+	basic := &BasicStruct{1, 2}
+	runTestWithCfg(t, "config_DisablePointerReplacement_simpleReusedStruct", &litter.Options{
+		DisablePointerReplacement: true,
+	}, []interface{}{basic, basic})
+	circular := &RecursiveStruct{}
+	circular.Ptr = circular
+	runTestWithCfg(t, "config_DisablePointerReplacement_circular", &litter.Options{
+		DisablePointerReplacement: true,
+	}, circular)
 }
 
 func TestSdump_multipleArgs(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/sanity-io/litter
 
+go 1.14
+
 require (
 	github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b // indirect
 	github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0 // indirect

--- a/testdata/config_DisablePointerReplacement_circular.dump
+++ b/testdata/config_DisablePointerReplacement_circular.dump
@@ -1,0 +1,3 @@
+&litter_test.RecursiveStruct{ // p0
+  Ptr: p0,
+}

--- a/testdata/config_DisablePointerReplacement_simpleReusedStruct.dump
+++ b/testdata/config_DisablePointerReplacement_simpleReusedStruct.dump
@@ -1,0 +1,10 @@
+[]interface {}{
+  &litter_test.BasicStruct{ // p0
+    Public: 1,
+    private: 2,
+  },
+  &litter_test.BasicStruct{ // p0
+    Public: 1,
+    private: 2,
+  },
+}


### PR DESCRIPTION
Adds new config flag `DisablePointerReplacement`. If enabled, it disables elision of reused pointers. For example, by default, a slice containing two pointers to the same struct will be emitted as:

```go
[]interface{} {
  &MyStruct{ // p0
    Foo: 1,
  },
  p0,
}
```

With `DisablePointerReplacement`, this becomes:

```go
[]interface{} {
  &MyStruct{ // p0
    Foo: 1,
  },
  &MyStruct{ // p0
    Foo: 1,
  },
}
```

This is useful to diffing, where collapsing the values would essentially induce spurious changes.

Also optimizes pointer handling to not use linear searches, which should significantly speed up large data structure dumping.