### PR TITLE
AddingPowerSupport_For_golang-github-sanity-io-litter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+arch:
+- amd64
+- ppc64le
+
 language: go
 go:
 - 1.14.x


### PR DESCRIPTION
Adding Power Support.

Adding power support ppc64le
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The Build is successful for both arch: amd64/ppc64le. Please find the Travis Link: https://travis-ci.com/github/santosh653/litter