### PR TITLE
Add DumpFunc option

### DIFF
--- a/dump_test.go
+++ b/dump_test.go
@@ -175,6 +175,22 @@ func TestSdump_config(t *testing.T) {
 	runTestWithCfg(t, "config_StrictGo", &litter.Options{
 		StrictGo: true,
 	}, data)
+	runTestWithCfg(t, "config_DumpFunc", &litter.Options{
+		DumpFunc: func(v reflect.Value, w io.Writer) bool {
+			if !v.CanInterface() {
+				return false
+			}
+			if b, ok := v.Interface().(bool); ok {
+				if b {
+					io.WriteString(w, `"on"`)
+				} else {
+					io.WriteString(w, `"off"`)
+				}
+				return true
+			}
+			return false
+		},
+	}, data)
 
 	basic := &BasicStruct{1, 2}
 	runTestWithCfg(t, "config_DisablePointerReplacement_simpleReusedStruct", &litter.Options{

--- a/testdata/config_DumpFunc.dump
+++ b/testdata/config_DumpFunc.dump
@@ -1,0 +1,19 @@
+[]interface {}{
+  litter_test.options{
+    Compact: bool"off",
+    StripPackageNames: bool"off",
+    HidePrivateFields: bool"on",
+    HomePackage: "",
+    Separator: " ",
+    StrictGo: bool"off",
+  },
+  &litter_test.BasicStruct{
+    Public: 1,
+    private: 2,
+  },
+  litter_test.Function,
+  &20,
+  &20,
+  litter.Dump,
+  func(string, int) (bool, error),
+}


### PR DESCRIPTION
Adds new config option DumpFunc which allows overriding any value's formatting. I don't think this is ready as-is, but I'm posting an early iteration to get feedback. 

My usecase is printing a yaml ast for debugging (specifically the `Node` https://pkg.go.dev/gopkg.in/yaml.v3#Node). The `Kind` field doesn't implement `fmt.Stringer` so it just shows up as a number. In that case, I'd add a dump func like this

``` go
package main

import (
	"fmt"
	"io"
	"reflect"

	"gopkg.in/yaml.v3"
)

func KindString(k yaml.Kind) string {
	switch k {
	case yaml.DocumentNode:
		return "DocumentNode"
	case yaml.SequenceNode:
		return "SequenceNode"
	case yaml.ScalarNode:
		return "MappingNode"
	case yaml.ScalarNode:
		return "ScalarNode"
	case yaml.AliasNode:
		return "AliasNode"
	default:
		return fmt.Sprintf("Unknown(%d)", k)
	}
}

func main() {
	cfg.DumpFunc = func(v reflect.Value, w io.Writer) bool {
		if !v.CanInterface() {
			return false
		}
		if k, ok := v.Interface().(yaml.Kind); ok {
			io.WriteString(w, KindString(k))
			return true
		}
		return false
	}
}
```