### PR TITLE
Fix pointer tracking to include type name when considering pointer identity

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -284,16 +284,14 @@ func (s *dumpState) dump(value interface{}) {
 func (s *dumpState) descendIntoPossiblePointer(value reflect.Value, f func()) {
 	canonicalize := true
 	if isPointerValue(value) {
-		ptr := value.Pointer()
-
 		// If elision disabled, and this is not a circular reference, don't canonicalize
-		if s.config.DisablePointerReplacement && s.parentPointers.add(ptr) {
+		if s.config.DisablePointerReplacement && s.parentPointers.add(value) {
 			canonicalize = false
 		}
 
 		// Add to stack of pointers we're recursively descending into
-		s.parentPointers.add(ptr)
-		defer s.parentPointers.remove(ptr)
+		s.parentPointers.add(value)
+		defer s.parentPointers.remove(value)
 	}
 
 	if !canonicalize {
@@ -435,9 +433,8 @@ func (s *dumpState) dumpVal(value reflect.Value) {
 // has been dumped before or not.
 func (s *dumpState) pointerNameFor(v reflect.Value) (string, bool) {
 	if isPointerValue(v) {
-		ptr := v.Pointer()
-		if info, ok := s.pointers[ptr]; ok {
-			firstVisit := s.visitedPointers.add(ptr)
+		if info, ok := s.pointers.get(v); ok {
+			firstVisit := s.visitedPointers.add(v)
 			return fmt.Sprintf("p%d", info.order), firstVisit
 		}
 	}


### PR DESCRIPTION
This fix is needed because it appears Go optimizes some values to point to the same location, which would otherwise cause the pointer names to be wrong.

## Example

Notice how `decoder` and `retrier` end up being the same pointer (they have the same `Pointer()` value):

```go
&elastic.Client{
  c: &http.Client{
    Transport: nil,
    CheckRedirect: ,
    Jar: nil,
    Timeout: 0,
  },
  connsMu: sync.RWMutex{
    w: sync.Mutex{
      state: 0,
      sema: 0,
    },
    writerSem: 0,
    readerSem: 0,
    readerCount: 0,
    readerWait: 0,
  },
  conns: []*elastic.conn{
    &elastic.conn{
      RWMutex: sync.RWMutex{
        w: sync.Mutex{
          state: 0,
          sema: 0,
        },
        writerSem: 0,
        readerSem: 0,
        readerCount: 0,
        readerWait: 0,
      },
      nodeID: "0Qu09zzXSe6VWlETWfm-pg",
      url: "http://127.0.0.1:9200",
      failures: 0,
      dead: false,
      deadSince: nil,
    },
  },
  cindex: -1,
  mu: sync.RWMutex{
    w: sync.Mutex{
      state: 0,
      sema: 0,
    },
    writerSem: 0,
    readerSem: 0,
    readerCount: 0,
    readerWait: 0,
  },
  urls: []string{
    "http://127.0.0.1:9200",
  },
  running: true,
  errorlog: nil,
  infolog: nil,
  tracelog: nil,
  deprecationlog: func(*http.Request, *http.Response),
  scheme: "http",
  healthcheckEnabled: true,
  healthcheckTimeoutStartup: 5000000000,
  healthcheckTimeout: 1000000000,
  healthcheckInterval: 60000000000,
  healthcheckStop: <chan bool Value>,
  snifferEnabled: true,
  snifferTimeoutStartup: 5000000000,
  snifferTimeout: 2000000000,
  snifferInterval: 900000000000,
  snifferCallback: elastic.SnifferCallback,
  snifferStop: <chan bool Value>,
  decoder: &elastic.DefaultDecoder{}, // p0
  basicAuth: false,
  basicAuthUsername: "",
  basicAuthPassword: "",
  sendGetBodyAs: "GET",
  gzipEnabled: false,
  requiredPlugins: nil,
  retrier: p0,
  headers: http.Header{
  },
}
```

After fix:

```go
&elastic.Client{
  c: &http.Client{
    Transport: nil,
    CheckRedirect: ,
    Jar: nil,
    Timeout: 0,
  },
  connsMu: sync.RWMutex{
    w: sync.Mutex{
      state: 0,
      sema: 0,
    },
    writerSem: 0,
    readerSem: 0,
    readerCount: 0,
    readerWait: 0,
  },
  conns: []*elastic.conn{
    &elastic.conn{
      RWMutex: sync.RWMutex{
        w: sync.Mutex{
          state: 0,
          sema: 0,
        },
        writerSem: 0,
        readerSem: 0,
        readerCount: 0,
        readerWait: 0,
      },
      nodeID: "0Qu09zzXSe6VWlETWfm-pg",
      url: "http://127.0.0.1:9200",
      failures: 0,
      dead: false,
      deadSince: nil,
    },
  },
  cindex: -1,
  mu: sync.RWMutex{
    w: sync.Mutex{
      state: 0,
      sema: 0,
    },
    writerSem: 0,
    readerSem: 0,
    readerCount: 0,
    readerWait: 0,
  },
  urls: []string{
    "http://127.0.0.1:9200",
  },
  running: true,
  errorlog: nil,
  infolog: nil,
  tracelog: nil,
  deprecationlog: func(*http.Request, *http.Response),
  scheme: "http",
  healthcheckEnabled: true,
  healthcheckTimeoutStartup: 5000000000,
  healthcheckTimeout: 1000000000,
  healthcheckInterval: 60000000000,
  healthcheckStop: <chan bool Value>,
  snifferEnabled: true,
  snifferTimeoutStartup: 5000000000,
  snifferTimeout: 2000000000,
  snifferInterval: 900000000000,
  snifferCallback: elastic.SnifferCallback,
  snifferStop: <chan bool Value>,
  decoder: &elastic.DefaultDecoder{},
  basicAuth: false,
  basicAuthUsername: "",
  basicAuthPassword: "",
  sendGetBodyAs: "GET",
  gzipEnabled: false,
  requiredPlugins: nil,
  retrier: &elastic.StopRetrier{},
  headers: http.Header{
  },
}
```
