### PR TITLE
Dump with Error()/String() if possible

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -315,13 +315,13 @@ func (s *dumpState) descendIntoPossiblePointer(value reflect.Value, f func()) {
 }
 
 func (s *dumpState) dumpVal(value reflect.Value) {
-	if value.Kind() == reflect.Ptr && value.IsNil() {
+	v := deInterface(value)
+	kind := v.Kind()
+
+	if kind == reflect.Ptr && v.IsNil() {
 		s.write([]byte("nil"))
 		return
 	}
-
-	v := deInterface(value)
-	kind := v.Kind()
 
 	// Try to handle with dump func
 	if s.config.DumpFunc != nil {

--- a/dump_test.go
+++ b/dump_test.go
@@ -50,6 +50,22 @@ func (csld CustomSingleLineDumper) LitterDump(w io.Writer) {
 	_, _ = w.Write([]byte("<custom>"))
 }
 
+type StructImplStringer struct{}
+
+func (s StructImplStringer) String() string {
+	return "String() called"
+}
+
+type StructImplError struct{}
+
+func (s StructImplError) String() string {
+	return "String() called"
+}
+
+func (s StructImplError) Error() string {
+	return "Error() called"
+}
+
 func TestSdump_primitives(t *testing.T) {
 	runTests(t, "primitives", []interface{}{
 		false,
@@ -227,6 +243,19 @@ func TestSdump_maps(t *testing.T) {
 		map[int]*BlankStruct{
 			2: &BlankStruct{},
 		},
+	})
+}
+
+func TestSdump_methods(t *testing.T) {
+	runTestWithCfg(t, "config_EnableMethods", &litter.Options{
+		DisableMethods: false,
+	}, []interface{}{
+		StructImplStringer{},
+		&StructImplStringer{},
+		(*StructImplStringer)(nil),
+		StructImplError{},
+		&StructImplError{},
+		(*StructImplError)(nil),
 	})
 }
 

--- a/testdata/config_EnableMethods.dump
+++ b/testdata/config_EnableMethods.dump
@@ -1,0 +1,8 @@
+[]interface {}{
+  litter_test.StructImplStringer String() called,
+  *litter_test.StructImplStringer String() called,
+  nil,
+  litter_test.StructImplError Error() called,
+  *litter_test.StructImplError Error() called,
+  nil,
+}


### PR DESCRIPTION
Dump with Error()/String() if possible, like `fmt`,  `spew`.

A `DisableMethods` config added, controlling the `Error()`, `String()`(should include `LittleDump`?) method invoking or not.

May be a solution of https://github.com/sanity-io/litter/issues/12.
