### PR TITLE
Better dumping for channels

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -239,6 +239,12 @@ func (s *dumpState) dumpFunc(v reflect.Value) {
 	}
 }
 
+func (s *dumpState) dumpChan(v reflect.Value) {
+	vType := v.Type()
+	res := []byte(vType.String())
+	s.write(res)
+}
+
 func (s *dumpState) dumpCustom(v reflect.Value, buf *bytes.Buffer) {
 
 	// Dump the type
@@ -422,6 +428,9 @@ func (s *dumpState) dumpVal(value reflect.Value) {
 
 	case reflect.Func:
 		s.dumpFunc(v)
+
+	case reflect.Chan:
+		s.dumpChan(v)
 
 	default:
 		if v.CanInterface() {

--- a/dump_test.go
+++ b/dump_test.go
@@ -53,6 +53,10 @@ func (csld CustomSingleLineDumper) LitterDump(w io.Writer) {
 }
 
 func TestSdump_primitives(t *testing.T) {
+	messages := make(chan string, 3)
+	sends := make(chan<- int64, 1)
+	receives := make(<-chan uint64)
+
 	runTests(t, "primitives", []interface{}{
 		false,
 		true,
@@ -85,6 +89,9 @@ func TestSdump_primitives(t *testing.T) {
 		interface{}(nil),
 		CustomMap{},
 		CustomMap(nil),
+		messages,
+		sends,
+		receives,
 	})
 }
 

--- a/testdata/primitives.dump
+++ b/testdata/primitives.dump
@@ -37,4 +37,7 @@
   nil,
   litter_test.CustomMap{},
   litter_test.CustomMap(nil),
+  chan string,
+  chan<- int64,
+  <-chan uint64,
 }


### PR DESCRIPTION
Currently a channel like;
```go
messages := make(chan string, 3)
````
is dumped as;
```
0xc000128540
```

With this change, it is now dumped as;
```go
chan string
```