### PR TITLE
Add time formatting support

### DIFF
--- a/dump_test.go
+++ b/dump_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -163,6 +164,7 @@ func TestSdump_config(t *testing.T) {
 		(func(v IntAlias) *IntAlias { return &v })(20),
 		litter.Dump,
 		func(s string, i int) (bool, error) { return false, nil },
+		time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
 
 	runTestWithCfg(t, "config_Compact", &litter.Options{
@@ -203,6 +205,9 @@ func TestSdump_config(t *testing.T) {
 			}
 			return false
 		},
+	}, data)
+	runTestWithCfg(t, "config_FormatTime", &litter.Options{
+		FormatTime: true,
 	}, data)
 
 	basic := &BasicStruct{1, 2}

--- a/testdata/config_Compact.dump
+++ b/testdata/config_Compact.dump
@@ -1,1 +1,1 @@
-[]interface{}{litter_test.options{Compact:false,StripPackageNames:false,HidePrivateFields:true,HomePackage:"",Separator:" ",StrictGo:false},&litter_test.BasicStruct{Public:1,private:2},litter_test.Function,&20,&20,litter.Dump,func(string,int)(bool,error)}
+[]interface{}{litter_test.options{Compact:false,StripPackageNames:false,HidePrivateFields:true,HomePackage:"",Separator:" ",StrictGo:false},&litter_test.BasicStruct{Public:1,private:2},litter_test.Function,&20,&20,litter.Dump,func(string,int)(bool,error),time.Time{wall:0,ext:63650361600,loc:nil}}

--- a/testdata/config_DumpFunc.dump
+++ b/testdata/config_DumpFunc.dump
@@ -16,4 +16,9 @@
   &20,
   litter.Dump,
   func(string, int) (bool, error),
+  time.Time{
+    wall: 0,
+    ext: 63650361600,
+    loc: nil,
+  },
 }

--- a/testdata/config_FieldFilter.dump
+++ b/testdata/config_FieldFilter.dump
@@ -9,4 +9,5 @@
   &20,
   litter.Dump,
   func(string, int) (bool, error),
+  time.Time{},
 }

--- a/testdata/config_FormatTime.dump
+++ b/testdata/config_FormatTime.dump
@@ -1,7 +1,11 @@
 []interface {}{
   litter_test.options{
+    Compact: false,
+    StripPackageNames: false,
     HidePrivateFields: true,
+    HomePackage: "",
     Separator: " ",
+    StrictGo: false,
   },
   &litter_test.BasicStruct{
     Public: 1,
@@ -12,8 +16,5 @@
   &20,
   litter.Dump,
   func(string, int) (bool, error),
-  time.Time{
-    wall: 0,
-    ext: 63650361600,
-  },
+  time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC),
 }

--- a/testdata/config_HidePrivateFields.dump
+++ b/testdata/config_HidePrivateFields.dump
@@ -15,4 +15,5 @@
   &20,
   litter.Dump,
   func(string, int) (bool, error),
+  time.Time{},
 }

--- a/testdata/config_HomePackage.dump
+++ b/testdata/config_HomePackage.dump
@@ -16,4 +16,9 @@
   &20,
   litter.Dump,
   func(string, int) (bool, error),
+  time.Time{
+    wall: 0,
+    ext: 63650361600,
+    loc: nil,
+  },
 }

--- a/testdata/config_StrictGo.dump
+++ b/testdata/config_StrictGo.dump
@@ -16,4 +16,9 @@
   (func(v litter_test.IntAlias) *litter_test.IntAlias { return &v })(20),
   litter.Dump,
   func(string, int) (bool, error),
+  time.Time{
+    wall: 0,
+    ext: 63650361600,
+    loc: nil,
+  },
 }

--- a/testdata/config_StripPackageNames.dump
+++ b/testdata/config_StripPackageNames.dump
@@ -16,4 +16,9 @@
   &20,
   Dump,
   func(string, int) (bool, error),
+  Time{
+    wall: 0,
+    ext: 63650361600,
+    loc: nil,
+  },
 }


### PR DESCRIPTION
Adds config option `FormatTime`. This formats like so:

```go
time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)
```
